### PR TITLE
👩‍💻‍ Improve type narrowing for hooks' arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Hooks now receive a single object argument instead of two positional arguments. This greatly helps with type narrowing if you check for the procedure name.
+
+  Before:
+
+  ```ts
+  Client(procedures, {
+    hooks: {
+      success(procedure, data) {
+        if (procedure === "getUser") {
+          // `data` is not narrowed down to the type returned by `getUser` :(
+        }
+      },
+    },
+  });
+  ```
+
+  After:
+
+  ```ts
+  Client(procedures, {
+    hooks: {
+      success({ procedure, data }) {
+        if (procedure === "getUser") {
+          // `data` is now correctly narrowed down to the type returned by `getUser` :)
+        }
+      },
+    },
+  });
+  ```
+
+  To update, simply change your hook implementations to use a single object argument and destructure (or not) the properties you need from it.
+
 ## [0.16.1] - 2025-11-12
 
 ### Fixed

--- a/src/client.ts
+++ b/src/client.ts
@@ -405,14 +405,23 @@ async function startClientListener<Procedures extends ProceduresMap>(
     // React to the data received: call hook, call handler,
     // and remove the request from pendingRequests (unless it's a progress update)
     if ("error" in data) {
-      ctx.hooks.error?.(data.functionName, new Error(data.error.message));
+      ctx.hooks.error?.({
+        procedure: data.functionName,
+        error: new Error(data.error.message),
+      });
       handlers.reject(new Error(data.error.message));
       pendingRequests.delete(requestId);
     } else if ("progress" in data) {
-      ctx.hooks.progress?.(data.functionName, data.progress);
+      ctx.hooks.progress?.({
+        procedure: data.functionName,
+        data: data.progress,
+      });
       handlers.onProgress(data.progress);
     } else if ("result" in data) {
-      ctx.hooks.success?.(data.functionName, data.result);
+      ctx.hooks.success?.({
+        procedure: data.functionName,
+        data: data.result,
+      });
       handlers.resolve(data.result);
       pendingRequests.delete(requestId);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,15 @@ export type ImplementationsMap<Procedures extends ProceduresMap> = {
   >;
 };
 
+type ProcedureNameAndData<
+  Procedures extends ProceduresMap,
+  Key extends "progress" | "success",
+  Name extends keyof Procedures = keyof Procedures,
+> = {
+  procedure: Name;
+  data: Schema.InferOutput<Procedures[Name][Key]>;
+};
+
 /**
  * Declaration of hooks to run on messages received from the server
  */
@@ -112,24 +121,15 @@ export type Hooks<Procedures extends ProceduresMap> = {
   /**
    * Called when a procedure call has been successful.
    */
-  success?: <Procedure extends keyof ProceduresMap>(
-    procedure: Procedure,
-    data: Schema.InferOutput<Procedures[Procedure]["success"]>,
-  ) => void;
+  success?: (arg: ProcedureNameAndData<Procedures, "success">) => void;
   /**
    * Called when a procedure call has failed.
    */
-  error?: <Procedure extends keyof ProceduresMap>(
-    procedure: Procedure,
-    error: Error,
-  ) => void;
+  error?: (arg: { procedure: keyof Procedures; error: Error }) => void;
   /**
    * Called when a procedure call sends progress updates.
    */
-  progress?: <Procedure extends keyof ProceduresMap>(
-    procedure: Procedure,
-    data: Schema.InferOutput<Procedures[Procedure]["progress"]>,
-  ) => void;
+  progress?: (arg: ProcedureNameAndData<Procedures, "progress">) => void;
 };
 
 /** @internal */

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -22,9 +22,9 @@ describe("Client hooks", { sequential: true }, async () => {
     await client.divide({ a: 6, b: 2 });
     expect(success).toHaveBeenCalledTimes(3);
     expect(success.mock.calls).toStrictEqual([
-      ["echo", "test"],
-      ["add", 3],
-      ["divide", 3],
+      [{ procedure: "echo", data: "test" }],
+      [{ procedure: "add", data: 3 }],
+      [{ procedure: "divide", data: 3 }],
     ]);
   });
 
@@ -41,8 +41,10 @@ describe("Client hooks", { sequential: true }, async () => {
       "Division by zero",
     );
     expect(error).toHaveBeenCalledTimes(1);
-    expect(error.mock.calls).toStrictEqual([["divide", expect.any(Error)]]);
-    expect(error.mock.calls[0][1].message).toBe("Division by zero");
+    expect(error.mock.calls).toStrictEqual([
+      [{ procedure: "divide", error: expect.any(Error) }],
+    ]);
+    expect(error.mock.calls[0][0].error.message).toBe("Division by zero");
   });
 
   test("progress hook is called on progress update", async () => {
@@ -57,9 +59,9 @@ describe("Client hooks", { sequential: true }, async () => {
     await client.divide({ a: 9, b: 3 });
     expect(progress).toHaveBeenCalledTimes(3);
     expect(progress.mock.calls).toStrictEqual([
-      ["divide", { percent: 33.33333333333333 }],
-      ["divide", { percent: 66.66666666666666 }],
-      ["divide", { percent: 100 }],
+      [{ procedure: "divide", data: { percent: 33.33333333333333 } }],
+      [{ procedure: "divide", data: { percent: 66.66666666666666 } }],
+      [{ procedure: "divide", data: { percent: 100 } }],
     ]);
   });
 });


### PR DESCRIPTION
Use a single object success({ procedure, data }) instead of two success(procedure, data)
